### PR TITLE
[FEAT] 사진 데이터 새로고침 시 유지 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@rive-app/react-canvas": "^4.18.6",
     "dom-to-image": "^2.6.0",
     "file-saver": "^2.0.5",
+    "idb-keyval": "^6.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.4.0"

--- a/src/context/PhotosContext.tsx
+++ b/src/context/PhotosContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useState, PropsWithChildren } from 'react';
+import { loadPhotos, savePhotos } from '@/utils/photoStorage';
+import { createContext, PropsWithChildren, useEffect, useState } from 'react';
 
 type PhotosContextType = {
   photos: string[];
@@ -11,6 +12,20 @@ export const PhotosContext = createContext<PhotosContextType | undefined>(
 
 export const PhotosProvider = ({ children }: PropsWithChildren) => {
   const [photos, setPhotos] = useState<string[]>([]);
+  const [isRestored, setIsRestored] = useState(false);
+
+  useEffect(() => {
+    loadPhotos().then(restored => {
+      if (restored) setPhotos(restored);
+      setIsRestored(true);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isRestored) {
+      savePhotos(photos);
+    }
+  }, [photos, isRestored]);
 
   return (
     <PhotosContext.Provider value={{ photos, setPhotos }}>

--- a/src/utils/photoStorage.ts
+++ b/src/utils/photoStorage.ts
@@ -1,0 +1,29 @@
+import { del, get, set } from 'idb-keyval';
+
+const STORAGE_KEY = 'toast_photos';
+
+export const savePhotos = async (photos: string[]) => {
+  try {
+    await set(STORAGE_KEY, photos);
+  } catch (e) {
+    console.error('IndexedDB 저장 실패', e);
+  }
+};
+
+export const loadPhotos = async (): Promise<string[] | null> => {
+  try {
+    const photos = await get<string[]>(STORAGE_KEY);
+    return photos ?? null;
+  } catch (e) {
+    console.error('IndexedDB 로딩 실패', e);
+    return null;
+  }
+};
+
+export const clearPhotos = async () => {
+  try {
+    await del(STORAGE_KEY);
+  } catch (e) {
+    console.error('IndexedDB 삭제 실패', e);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,6 +1476,11 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+idb-keyval@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.1.tgz#94516d625346d16f56f3b33855da11bfded2db33"
+  integrity sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==
+
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"


### PR DESCRIPTION
## ✅ 주요 변경 사항
사용자가 촬영한 네컷 사진 데이터를 새로고침 후에도 유지되도록 저장 로직 추가

IndexedDB 을 사용해서 스토리지 처리 
idb-keyval 라이브러리 사용해 비동기 저장 및 복원 처리

초기 복원 후 상태 저장이 덮어쓰는 문제를 방지하기 위해 isRestored 플래그 도입