### PR TITLE
[BUG] WebAssembly 로딩 오류 및 video.play() 중단 이슈를 해결한다. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.13.3",
+    "@rive-app/canvas": "^2.26.9",
     "@rive-app/react-canvas": "^4.18.6",
     "dom-to-image": "^2.6.0",
     "file-saver": "^2.0.5",

--- a/src/hooks/useTakePhoto.ts
+++ b/src/hooks/useTakePhoto.ts
@@ -19,7 +19,11 @@ const useTakePhoto = () => {
         const video = videoRef.current;
         if (video) {
           video.srcObject = stream;
-          video.play();
+          video.onloadedmetadata = () => {
+            video.play().catch(err => {
+              console.warn('Video play interrupted:', err);
+            });
+          };
         }
       })
       .catch(error => {

--- a/src/hooks/useToasterRiv.ts
+++ b/src/hooks/useToasterRiv.ts
@@ -1,4 +1,5 @@
 import ToasterRiveImg from '@/assets/rive/toaster.riv?url';
+import riveWasmUrl from '@rive-app/canvas/rive.wasm?url';
 import {
   EventCallback,
   EventType,
@@ -24,7 +25,7 @@ interface Props {
   takePhoto: () => void;
 }
 
-RuntimeLoader.setWasmUrl(ToasterRiveImg);
+RuntimeLoader.setWasmUrl(riveWasmUrl);
 
 const useToasterRiv = ({ takePhoto }: Props) => {
   const { rive, RiveComponent } = useRive({

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,11 @@
   resolved "https://registry.yarnpkg.com/@rive-app/canvas/-/canvas-2.26.7.tgz#593ccc6d875e42feaae001a3e5052fa0627933fe"
   integrity sha512-0/L3jsLdpVXfZHqkK6famgLQf7wFT1TuWrB4A8I8K+/uLPulpTK76/jJ78odCdZ7WyO5OpRkK2OwuW5MvH4qJg==
 
+"@rive-app/canvas@^2.26.9":
+  version "2.26.9"
+  resolved "https://registry.yarnpkg.com/@rive-app/canvas/-/canvas-2.26.9.tgz#d32ad8a9ff74307770085b36d578a208e60c26f2"
+  integrity sha512-XQVv6iMqUs1gjm9Jsuf2Seqh8hj6mrciJxkybDD3XdtVQJ4SGGux2yvMHunctKDSabqb049silKZLbFRMny+ew==
+
 "@rive-app/react-canvas@^4.18.6":
   version "4.18.6"
   resolved "https://registry.yarnpkg.com/@rive-app/react-canvas/-/react-canvas-4.18.6.tgz#772b403752907f7a2da46a57bfc2949d799d4218"


### PR DESCRIPTION
## ⚠️ 관련 이슈
- #22 

## 📌 문제 상황 
- Rive 애니메이션 실행 시 WebAssembly 로딩 오류 발생
- 웹캠 사용 시 video.play() 호출이 중단되며 AbortError 발생


## ✅ 수정 사항

### 1. WebAssembly MIME 타입 오류 해결

**에러 메시지:**  
```
wasm streaming compile failed: TypeError: Incorrect response MIME type. Expected 'application/wasm'.
```

**원인:**  
`.riv` 파일에서 wasm 경로를 설정할 때, `RuntimeLoader.setWasmUrl()`에 전달된 `.wasm` 파일을 보낸게 아니라서 브라우저에서 올바르게 인식되지 않음.  

**해결 방법:**

- '.wasm' 파일로 변경해줌 
  ```ts
  import riveWasmUrl from '@rive-app/canvas/rive.wasm';
  RuntimeLoader.setWasmUrl(riveWasmUrl);
  ```

그러자 타입스크립트가 `.wasm`을 import할 수 없다는 타입 에러도 함께 발생.
 
- `.wasm` 파일을 `?url` 쿼리로 import → 정적 URL로 처리됨
  ```ts
  import riveWasmUrl from '@rive-app/canvas/rive.wasm?url';
  ```


### 2. `video.play()` 중단 오류 (AbortError) 해결

**에러 메시지:**  
```
AbortError: The play() request was interrupted by a new load request.
```

**원인:**  
비동기적으로 `video.play()`가 호출되기 전에 `video.srcObject`가 변경되면서, 브라우저가 기존 재생 요청을 중단함.

**해결 방법:**

- `video.srcObject` 설정 후 `onloadedmetadata` 이벤트를 기다린 뒤에 `play()` 실행
  ```ts
  video.srcObject = stream;
  video.onloadedmetadata = () => {
    video.play().catch(err => console.warn('Play failed:', err));
  };
  ```
