### PR TITLE
[FIX] 모바일에서의 사진 눌림 버그, 사파리 다운로드 실패 이슈 등을 해결하고 모바일에서 촬영 기능이 동작하게 한다. 

### DIFF
--- a/src/components/_common/Layout/MainLayout.tsx
+++ b/src/components/_common/Layout/MainLayout.tsx
@@ -1,11 +1,6 @@
-import { MobileBlocker } from '@/components/etc';
-import { useIsMobileDevice } from '@/hooks';
 import { PropsWithChildren } from 'react';
 
 const MainLayout = ({ children }: PropsWithChildren) => {
-  const isMobile = useIsMobileDevice();
-  if (isMobile) return <MobileBlocker />;
-
   return (
     <div className="w-full min-h-screen h-full mx-auto px-4 sm:px-6 md:px-8 max-w-screen-xl mt-2">
       <div className="flex flex-col w-full h-full">{children}</div>

--- a/src/components/camera/Camera.tsx
+++ b/src/components/camera/Camera.tsx
@@ -9,12 +9,15 @@ const Camera = ({ videoRef, canvasRef }: Props) => {
     <>
       <video
         ref={videoRef}
+        autoPlay
+        muted
+        playsInline
         className="absolute w-4/6 md:w-4/5 max-w-[480px] aspect-video 
-      -translate-x-1/2 object-contain scale-x-[-1]
-      z-0 rounded-2xl shadow-md"
+    -translate-x-1/2 object-contain scale-x-[-1]
+    z-0 rounded-2xl shadow-md
+    bottom-[8%] md:bottom-[11.5%]"
         style={{
           left: '39%',
-          bottom: '11.5%',
           objectFit: 'cover',
         }}
       />

--- a/src/components/camera/MobileCamera.tsx
+++ b/src/components/camera/MobileCamera.tsx
@@ -19,8 +19,8 @@ const MobileCamera = ({ videoRef, canvasRef }: Props) => {
       <canvas
         className="hidden"
         ref={canvasRef}
-        width="1080"
-        height="1920"
+        width="1920"
+        height="1080"
       ></canvas>
     </>
   );

--- a/src/components/camera/MobileCamera.tsx
+++ b/src/components/camera/MobileCamera.tsx
@@ -1,0 +1,29 @@
+import { RefObject } from 'react';
+
+interface Props {
+  videoRef: RefObject<HTMLVideoElement | null>;
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+}
+const MobileCamera = ({ videoRef, canvasRef }: Props) => {
+  return (
+    <>
+      <video
+        ref={videoRef}
+        autoPlay
+        muted
+        playsInline
+        className="absolute w-full h-full top-1/2 left-1/2 
+            -translate-x-1/2 -translate-y-1/2 scale-x-[-1] 
+            object-cover z-0 shadow-md"
+      />
+      <canvas
+        className="hidden"
+        ref={canvasRef}
+        width="1080"
+        height="1920"
+      ></canvas>
+    </>
+  );
+};
+
+export default MobileCamera;

--- a/src/components/camera/MobileCamera.tsx
+++ b/src/components/camera/MobileCamera.tsx
@@ -4,6 +4,7 @@ interface Props {
   videoRef: RefObject<HTMLVideoElement | null>;
   canvasRef: RefObject<HTMLCanvasElement | null>;
 }
+
 const MobileCamera = ({ videoRef, canvasRef }: Props) => {
   return (
     <>

--- a/src/components/camera/MobileCameraSection.tsx
+++ b/src/components/camera/MobileCameraSection.tsx
@@ -1,0 +1,18 @@
+import Button from '@/components/_common/Button/Button';
+import MobileCamera from '@/components/camera/MobileCamera';
+import { useTakePhoto } from '@/hooks';
+
+const MobileCameraSection = () => {
+  const { videoRef, canvasRef, photos, takePhoto } = useTakePhoto();
+
+  return (
+    <section className="flex flex-col items-center w-full h-dvh bg-green-50">
+      <div className="relative w-full h-[70dvh]">
+        <MobileCamera videoRef={videoRef} canvasRef={canvasRef} />
+      </div>
+      <Button label="타이머 버튼 위치" size="full" onClick={takePhoto} />
+    </section>
+  );
+};
+
+export default MobileCameraSection;

--- a/src/components/camera/MobileCameraSection.tsx
+++ b/src/components/camera/MobileCameraSection.tsx
@@ -1,6 +1,6 @@
-import Button from '@/components/_common/Button/Button';
-import MobileCamera from '@/components/camera/MobileCamera';
-import useTakeMobilePhoto from '@/hooks/useTakeMobilePhoto';
+import { Button } from '@/components';
+import { MobileCamera } from '@/components/camera';
+import { useTakeMobilePhoto } from '@/hooks';
 
 const MobileCameraSection = () => {
   const { videoRef, canvasRef, takePhoto } = useTakeMobilePhoto();
@@ -10,7 +10,7 @@ const MobileCameraSection = () => {
       <div className="relative w-full h-full border-2 border-red-600">
         <MobileCamera videoRef={videoRef} canvasRef={canvasRef} />
       </div>
-      <Button label="타이머 버튼 위치" size="full" onClick={takePhoto} />
+      <Button label="촬영 버튼" size="full" onClick={takePhoto} />
     </section>
   );
 };

--- a/src/components/camera/MobileCameraSection.tsx
+++ b/src/components/camera/MobileCameraSection.tsx
@@ -1,13 +1,13 @@
 import Button from '@/components/_common/Button/Button';
 import MobileCamera from '@/components/camera/MobileCamera';
-import { useTakePhoto } from '@/hooks';
+import useTakeMobilePhoto from '@/hooks/useTakeMobilePhoto';
 
 const MobileCameraSection = () => {
-  const { videoRef, canvasRef, photos, takePhoto } = useTakePhoto();
+  const { videoRef, canvasRef, takePhoto } = useTakeMobilePhoto();
 
   return (
-    <section className="flex flex-col items-center w-full h-dvh bg-green-50">
-      <div className="relative w-full h-[70dvh]">
+    <section className="flex flex-col items-center w-full h-[70dvh] bg-green-50 border-2 border-amber-400">
+      <div className="relative w-full h-full border-2 border-red-600">
         <MobileCamera videoRef={videoRef} canvasRef={canvasRef} />
       </div>
       <Button label="타이머 버튼 위치" size="full" onClick={takePhoto} />

--- a/src/components/camera/index.ts
+++ b/src/components/camera/index.ts
@@ -1,3 +1,4 @@
 export { default as Camera } from './Camera';
 export { default as CameraSection } from './CameraSection';
+export { default as MobileCamera } from './MobileCamera';
 export { default as MobileCameraSection } from './MobileCameraSection';

--- a/src/components/camera/index.ts
+++ b/src/components/camera/index.ts
@@ -1,2 +1,3 @@
 export { default as Camera } from './Camera';
 export { default as CameraSection } from './CameraSection';
+export { default as MobileCameraSection } from './MobileCameraSection';

--- a/src/components/landing/IntroSection.tsx
+++ b/src/components/landing/IntroSection.tsx
@@ -20,7 +20,9 @@ const IntroSection = () => {
         오늘의 사진, 오늘의 토스트 🌞
       </p>
       <p className="text-2xl text-amber-800 mb-8">
-        마음에 드는 재료를 골라, 나만의 토스트를 만들어보세요!
+        마음에 드는 재료를 골라,
+        <br className="md:hidden" />
+        나만의 토스트를 만들어보세요!
         <br />
         귀여운 네컷 사진으로 추억을 담아요 📸
       </p>

--- a/src/components/preview/MobilePreviewSection.tsx
+++ b/src/components/preview/MobilePreviewSection.tsx
@@ -1,0 +1,31 @@
+import { usePhotosContext } from '@/hooks';
+
+const MobilePreviewSection = () => {
+  const { photos } = usePhotosContext();
+
+  return (
+    <section className="flex justify-center items-center overflow-x-auto w-full h-[150px] bg-amber-800">
+      <div className="w-[150px] h-[90dvw] rotate-90 bg-blue-50 flex flex-col items-center justify-center gap-4 px-4">
+        {Array.from({ length: 4 }).map((_, index) => {
+          const photo = photos[index];
+
+          return photo ? (
+            <img
+              key={index}
+              src={photo}
+              alt={`photo-${index}`}
+              className="w-[120px] rounded-lg shadow-md object-contain scale-x-[-1]"
+            />
+          ) : (
+            <div
+              key={index}
+              className="w-[120px] h-[160px] bg-white rounded-lg shadow-inner border border-gray-300"
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default MobilePreviewSection;

--- a/src/components/preview/MobilePreviewSection.tsx
+++ b/src/components/preview/MobilePreviewSection.tsx
@@ -8,7 +8,6 @@ const MobilePreviewSection = () => {
       <div className="w-[150px] h-[90dvw] rotate-90 bg-blue-50 flex flex-col items-center justify-center gap-4 px-4">
         {Array.from({ length: 4 }).map((_, index) => {
           const photo = photos[index];
-
           return photo ? (
             <img
               key={index}

--- a/src/components/preview/ToastFrameCut.tsx
+++ b/src/components/preview/ToastFrameCut.tsx
@@ -9,14 +9,14 @@ const ToastFrameCut = ({ photo }: Props) => {
     <div className="relative w-[260px]">
       <img src={toastImg} width={260} />
       {photo && (
-        <img
-          src={photo}
-          key={`Captured-${photo}`}
-          alt={`Captured-${photo}`}
-          className={`absolute transform -scale-x-100 z-10 rounded-xl top-15 left-8`}
-          width="200"
-          height="112"
-        />
+        <div className="w-[200px] aspect-[16/9] absolute transform scale-x-[-1] z-10 top-15 left-8">
+          <img
+            src={photo}
+            key={`Captured-${photo}`}
+            alt={`Captured-${photo}`}
+            className={`object-cover rounded-xl`}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/preview/index.ts
+++ b/src/components/preview/index.ts
@@ -1,3 +1,4 @@
+export { default as MobilePreviewSection } from './MobilePreviewSection';
 export { default as PreviewSection } from './PreviewSection';
 export { default as ToastFrame } from './ToastFrame';
 export { default as ToastFrameCut } from './ToastFrameCut';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,5 +6,6 @@ export { default as useGetFramesByEvent } from './useGetFramesByEvent';
 export { default as useIsMobileDevice } from './useIsMobileDevice';
 export { default as usePhotoDownload } from './usePhotoDownload';
 export { default as usePhotosContext } from './usePhotosContext';
+export { default as useTakeMobilePhoto } from './useTakeMobilePhoto';
 export { default as useTakePhoto } from './useTakePhoto';
 export { default as useToasterRiv } from './useToasterRiv';

--- a/src/hooks/usePhotoDownload.ts
+++ b/src/hooks/usePhotoDownload.ts
@@ -1,7 +1,7 @@
+import { buildBlobWithRetry } from '@/utils/buildBlobWithRetry';
 import { getFormatDate } from '@/utils/getFormatDate';
 import { isSafari } from '@/utils/isSafari';
 import saveAs from 'file-saver';
-import { toBlob } from 'html-to-image';
 import { useRef, useState } from 'react';
 
 const usePhotoDownload = () => {
@@ -32,18 +32,15 @@ const usePhotoDownload = () => {
     try {
       await Promise.all(loadPromises);
       if (isSafari()) {
-        await new Promise(resolve => setTimeout(resolve, 10 * 1000));
+        await new Promise(resolve => setTimeout(resolve, 3000));
       }
 
-      const blob = await toBlob(downloadDivRef.current, {
-        cacheBust: true,
-        pixelRatio: 3,
-      });
+      const blob = await buildBlobWithRetry(downloadDivRef.current, isSafari());
 
       if (blob) {
         saveAs(blob, `toaster-booth-${getFormatDate(new Date())}.png`);
       } else {
-        console.error('Blob 생성 실패');
+        console.error('Blob 생성 실패 - Safari에서 이미지 누락 가능성 있음');
       }
     } catch (error) {
       console.error('Error converting div to image:', error);

--- a/src/hooks/useTakeMobilePhoto.ts
+++ b/src/hooks/useTakeMobilePhoto.ts
@@ -56,16 +56,18 @@ const useTakeMobilePhoto = () => {
 
     if (video && canvas) {
       const context = canvas.getContext('2d');
-      if (context) {
-        context.translate(canvas.width, 0);
-        context.rotate((90 * Math.PI) / 180);
+      if (!context) return;
 
-        context.drawImage(video, 0, 0, canvas.height, canvas.width);
-        context.restore();
+      context.save();
 
-        const imageData = canvas.toDataURL('image/png');
-        setPhotos(prev => [...prev, imageData]);
-      }
+      context.translate(canvas.width, 0);
+      context.rotate((90 * Math.PI) / 180);
+
+      context.drawImage(video, 0, 0, canvas.height, canvas.width);
+      context.restore();
+
+      const imageData = canvas.toDataURL('image/png');
+      setPhotos(prev => [...prev, imageData]);
     }
   };
 

--- a/src/hooks/useTakeMobilePhoto.ts
+++ b/src/hooks/useTakeMobilePhoto.ts
@@ -1,4 +1,5 @@
 import { usePhotosContext } from '@/hooks';
+import { trackTakeToasterButton } from '@/service/amplitude/trackEvent';
 import { useEffect, useRef, useState } from 'react';
 
 const useTakeMobilePhoto = () => {
@@ -49,7 +50,7 @@ const useTakeMobilePhoto = () => {
   };
 
   const takePhoto = () => {
-    // trackTakeToasterButton();
+    trackTakeToasterButton();
 
     const canvas = canvasRef.current;
     const video = videoRef.current;
@@ -82,7 +83,6 @@ const useTakeMobilePhoto = () => {
   return {
     videoRef,
     canvasRef,
-    photos,
     takePhoto,
     closeCamera,
   };

--- a/src/hooks/useTakeMobilePhoto.ts
+++ b/src/hooks/useTakeMobilePhoto.ts
@@ -1,0 +1,89 @@
+import { usePhotosContext } from '@/hooks';
+import { useEffect, useRef, useState } from 'react';
+
+const useTakeMobilePhoto = () => {
+  const { photos, setPhotos } = usePhotosContext();
+
+  const [streamVideo, setStreamVideo] = useState<MediaStream | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const openCamera = () => {
+    navigator.mediaDevices
+      .getUserMedia({
+        video: {
+          width: 1920,
+          height: 1080,
+          facingMode: 'user',
+        },
+      })
+      .then(stream => {
+        setStreamVideo(stream);
+        const video = videoRef.current;
+        if (video) {
+          video.srcObject = stream;
+          video.onloadedmetadata = () => {
+            video.play().catch(err => {
+              console.warn('Video play interrupted:', err);
+            });
+          };
+        }
+      })
+      .catch(error => {
+        console.error('Error opening camera:', error);
+      });
+  };
+
+  const closeCamera = () => {
+    if (videoRef.current) {
+      videoRef.current.pause();
+      videoRef.current.srcObject = null;
+    }
+
+    if (streamVideo) {
+      streamVideo.getTracks().forEach(track => {
+        track.stop();
+      });
+      setStreamVideo(null);
+    }
+  };
+
+  const takePhoto = () => {
+    // trackTakeToasterButton();
+
+    const canvas = canvasRef.current;
+    const video = videoRef.current;
+
+    if (video && canvas) {
+      const context = canvas.getContext('2d');
+      if (context) {
+        context.translate(canvas.width, 0);
+        context.rotate((90 * Math.PI) / 180);
+
+        context.drawImage(video, 0, 0, canvas.height, canvas.width);
+        context.restore();
+
+        const imageData = canvas.toDataURL('image/png');
+        setPhotos(prev => [...prev, imageData]);
+      }
+    }
+  };
+
+  useEffect(() => {
+    openCamera();
+  }, []);
+
+  useEffect(() => {
+    if (photos.length === 4) closeCamera();
+  }, [photos]);
+
+  return {
+    videoRef,
+    canvasRef,
+    photos,
+    takePhoto,
+    closeCamera,
+  };
+};
+
+export default useTakeMobilePhoto;

--- a/src/hooks/useTakePhoto.ts
+++ b/src/hooks/useTakePhoto.ts
@@ -12,7 +12,11 @@ const useTakePhoto = () => {
   const openCamera = () => {
     navigator.mediaDevices
       .getUserMedia({
-        video: { width: 1920, height: 1080, facingMode: 'user' },
+        video: {
+          width: 1920,
+          height: 1080,
+          facingMode: 'user',
+        },
       })
       .then(stream => {
         setStreamVideo(stream);

--- a/src/hooks/useTakePhoto.ts
+++ b/src/hooks/useTakePhoto.ts
@@ -57,11 +57,11 @@ const useTakePhoto = () => {
 
     if (video && canvas) {
       const context = canvas.getContext('2d');
-      if (context) {
-        context.drawImage(video, 0, 0, canvas.width, canvas.height);
-        const imageData = canvas.toDataURL('image/png');
-        setPhotos(prev => [...prev, imageData]);
-      }
+      if (!context) return;
+
+      context.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const imageData = canvas.toDataURL('image/png');
+      setPhotos(prev => [...prev, imageData]);
     }
   };
 

--- a/src/pages/TakePhotoMobilePage.tsx
+++ b/src/pages/TakePhotoMobilePage.tsx
@@ -1,5 +1,5 @@
 import { MobileCameraSection } from '@/components/camera';
-import MobilePreviewSection from '@/components/preview/MobilePreviewSection';
+import { MobilePreviewSection } from '@/components/preview';
 
 const TakePhotoMobilePage = () => {
   return (

--- a/src/pages/TakePhotoMobilePage.tsx
+++ b/src/pages/TakePhotoMobilePage.tsx
@@ -1,0 +1,16 @@
+import { MobileCameraSection } from '@/components/camera';
+import MobilePreviewSection from '@/components/preview/MobilePreviewSection';
+
+const TakePhotoMobilePage = () => {
+  return (
+    <div className="flex flex-col w-full h-full bg-pink-50 mt-[50px]">
+      {/* 프리뷰 사진 섹션 */}
+      <MobilePreviewSection />
+
+      {/* 카메라 섹션 */}
+      <MobileCameraSection />
+    </div>
+  );
+};
+
+export default TakePhotoMobilePage;

--- a/src/pages/TakePhotoPage.tsx
+++ b/src/pages/TakePhotoPage.tsx
@@ -1,7 +1,8 @@
 import { CameraSection } from '@/components/camera';
 import { PreviewSection } from '@/components/preview';
 import { ROUTE_PATH } from '@/constants/routePath';
-import { useEventNavigate, usePhotosContext } from '@/hooks';
+import { useEventNavigate, useIsMobileDevice, usePhotosContext } from '@/hooks';
+import { TakePhotoMobilePage } from '@/pages';
 import { useTrackPageView } from '@/service/amplitude';
 import { useEffect } from 'react';
 
@@ -14,6 +15,9 @@ const TakePhotoPage = () => {
   useEffect(() => {
     if (photos.length >= 4) navigate(ROUTE_PATH.customPhoto);
   }, [photos]);
+
+  const isMobile = useIsMobileDevice();
+  if (isMobile) return <TakePhotoMobilePage />;
 
   return (
     <div className="flex flex-row flex-wrap items-center justify-center w-full h-full">

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,4 +2,5 @@ export { default as CustomPhotoPage } from './CustomPhotoPage';
 export { default as NotFoundPage } from './NotFoundPage';
 export { default as SavePhotoPage } from './SavePhotoPage';
 export { default as StartPage } from './StartPage';
+export { default as TakePhotoMobilePage } from './TakePhotoMobilePage';
 export { default as TakePhotoPage } from './TakePhotoPage';

--- a/src/styles/system.ts
+++ b/src/styles/system.ts
@@ -4,7 +4,7 @@ export const sizeStyle: Record<string, string> = {
   small: 'px-2 py-1 text-sm h-10',
   medium: 'px-4 py-2 text-base h-12',
   large: 'px-6 py-3 text-lg h-16',
-  full: 'w-full',
+  full: 'h-12 w-full',
 };
 
 export const colorStyle: Record<string, string> = {

--- a/src/utils/buildBlobWithRetry.ts
+++ b/src/utils/buildBlobWithRetry.ts
@@ -1,0 +1,27 @@
+import { toBlob } from 'html-to-image';
+
+export const buildBlobWithRetry = async (
+  element: HTMLElement,
+  isMobile: boolean,
+  minBlobSize = 500_000,
+  maxAttempts = 10,
+) => {
+  let blob: Blob | null = null;
+  let attempt = 0;
+
+  while (attempt < maxAttempts) {
+    blob = await toBlob(element, {
+      cacheBust: true,
+      pixelRatio: isMobile ? 2 : 3,
+    });
+
+    if (blob && blob.size > minBlobSize) {
+      break;
+    }
+
+    attempt += 1;
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  return blob;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,10 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss(), tsconfigPaths(), svgr()],
+  server: {
+    host: true,
+    allowedHosts: [
+      '*.ngrok-free.app', // ngrok-free.app 주소 추가
+    ],
+  },
 });


### PR DESCRIPTION
## 🍀 관련 이슈 

- #13 
- #35 

## 📌 문제 요약

## 모바일 회전 방향 일관성 문제 대응
- 촬영 기준 방향을 고정: 다양한 디바이스/브라우저 환경에서 orientation 정보를 안정적으로 얻기 어려워, "핸드폰 오른쪽이 위"인 상태에서 촬영하는 방향을 기준 방향으로 명시하고 이에 맞춰 canvas.drawImage 처리 방식 통일
- canvas 캡처 시 무조건 90도 회전 (context.translate + rotate) 로 처리

### ☢️ 시도한 것들
- screen.orientation.angle 값을 활용해 회전 각도에 따라 canvas 방향을 다르게 처리하려 했으나, 일부 브라우저(Safari 등)에서는 값이 항상 0도로 나오는 문제가 있었음
- DeviceOrientationEvent 센서로 각도를 직접 측정해보려 했으나, iOS 환경에서는 권한 요청 없이 동작하지 않거나, 값이 들어오지 않는 케이스가 많아 실용성이 떨어짐


## Safari에서 이미지 다운로드 시 누락되는 현상 대응
- Safari 브라우저에서 `html-to-image`를 사용해 이미지 다운로드 시, 내부 이미지가 누락된 채 Blob이 생성되는 문제가 발생.
    - 이는 Safari가 비동기 이미지 로딩을 최종 렌더링에 반영하지 않고 PNG를 생성해버리는 브라우저 특성 때문입니다.

### 🔍 원인 분석

- `html-to-image` 내부의 렌더링이 백그라운드에서 비동기적으로 진행되며, Safari는 `img.onload`를 기다리지 않고 렌더링을 강행하는 것으로 보인다.
- 일반적인 브라우저에서는 문제가 없지만, Safari에서는 Blob 생성 시점에 이미지가 아직 로딩되지 않아 빈 이미지가 출력됩니다.

### ✅ 해결 방법

- 모든 `<img>` 요소의 로딩이 완료될 때까지 `Promise.all`로 대기 처리
- Safari인 경우 렌더링 타이밍 보정을 위해 추가적인 `setTimeout` 대기 로직 적용
- **다운로드된 Blob의 크기를 기반으로 반복 시도**하는 안전장치 추가 (Safari에서 발생 가능한 비정상 Blob 대응)

```ts
let dataUrl = '';
const minDataLength = 2000000;
let i = 0;
while (dataUrl.length < minDataLength && i < maxAttempts) {
  dataUrl = await toPng(element);
  i += 1;
}
```

## ❄️ 확인사항 

현재 모바일 rive 작업 진행 중임으로 모바일 기능 blocker 가 아직 작동하고 있어야함. 
