### PR TITLE
[FEAT] 로그인한 유저가 찍은 사진을 자동으로 아카이빙 할 수 있게 한다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "idb-keyval": "^6.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-error-boundary": "^5.0.0",
     "react-router-dom": "^7.4.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
+import { GlobalError, GlobalLoading } from '@/components';
 import { FilterProvider, FrameProvider, PhotosProvider } from '@/context';
 import { UserProvider } from '@/context/UserContext';
-import router from '@/router';
+import { router } from '@/router';
 import { amplitudeInitializer } from '@/service/amplitude/amplitudeInitializer';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Suspense, useEffect } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { RouterProvider } from 'react-router-dom';
+
 import '@/styles/global.css';
 import '@/styles/tailwind.css';
 import '@/styles/theme.css';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { RouterProvider } from 'react-router-dom';
 
 const { init } = amplitudeInitializer();
 const queryClient = new QueryClient();
@@ -23,7 +26,11 @@ function App() {
         <FilterProvider>
           <PhotosProvider>
             <FrameProvider>
-              <RouterProvider router={router} />
+              <ErrorBoundary fallback={<GlobalError />}>
+                <Suspense fallback={<GlobalLoading />}>
+                  <RouterProvider router={router} />
+                </Suspense>
+              </ErrorBoundary>
             </FrameProvider>
           </PhotosProvider>
         </FilterProvider>

--- a/src/components/Login/AuthSection.tsx
+++ b/src/components/Login/AuthSection.tsx
@@ -1,6 +1,6 @@
 import { LoginSection } from '@/components/Login/LoginSection';
 import { MypageButton } from '@/components/Login/MypageButton';
-import useUserContext from '@/hooks/useUserContext';
+import { useUserContext } from '@/hooks';
 
 export const AuthSection = () => {
   const { user } = useUserContext();

--- a/src/components/_common/Header/Header.tsx
+++ b/src/components/_common/Header/Header.tsx
@@ -30,7 +30,7 @@ const Header = () => {
       ${isScrolled ? 'md:bg-yellow-50 md:shadow-sm' : 'md:bg-transparent'}
     `}
     >
-      <div className="flex flex-row justify-between items-center w-full h-full md:max-w-3/4 mx-auto">
+      <div className="flex flex-row justify-between items-center w-full h-full md:max-w-3/4 mx-auto px-1">
         <TextToasterIcon width={150} height={40} onClick={handleReturn} />
 
         <AuthSection />

--- a/src/components/_common/Layout/GlobalError.tsx
+++ b/src/components/_common/Layout/GlobalError.tsx
@@ -1,0 +1,8 @@
+export const GlobalError = () => (
+  <div className="flex flex-col items-center justify-center w-screen h-screen bg-red-50">
+    <div className="text-lg text-red-500 font-semibold">
+      토스터가 고장났어요! 😭
+    </div>
+    <div className="text-gray-600 mt-2">잠시 후 다시 시도해 주세요.</div>
+  </div>
+);

--- a/src/components/_common/Layout/GlobalLoading.tsx
+++ b/src/components/_common/Layout/GlobalLoading.tsx
@@ -1,0 +1,7 @@
+export const GlobalLoading = () => (
+  <div className="flex flex-col items-center justify-center w-screen h-screen bg-yellow-50">
+    <div className="text-lg text-amber-600 font-semibold animate-pulse">
+      토스터 예열 중...
+    </div>
+  </div>
+);

--- a/src/components/gallery/GalleryContentSkeleton.tsx
+++ b/src/components/gallery/GalleryContentSkeleton.tsx
@@ -1,0 +1,22 @@
+export const GalleryContentSkeleton = () => {
+  return (
+    <div className="relative">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        {Array.from({ length: 5 }).map((_, idx) => (
+          <div
+            key={`gallery-skeleton-${idx}`}
+            className={`w-fit p-4 rounded-xl overflow-hidden shadow-md bg-gray-100 animate-pulse`}
+          >
+            <div className="w-[180px] h-[500px] bg-gray-300 rounded-lg" />
+          </div>
+        ))}
+      </div>
+
+      <div className="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-white/30">
+        <div className="text-amber-500 text-lg font-semibold animate-pulse">
+          사진을 불러오는 중이에요 📸
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -1,14 +1,14 @@
-import { GalleryModal } from '@/components/gallery/GalleryModal';
+import { GalleryModal } from '@/components/gallery';
 import { Photo } from '@/types/photo';
 import { getFormatDate } from '@/utils/getFormatDate';
 import { useState } from 'react';
 
-interface Props {
-  photo: Photo;
-}
-export const GalleryItem = ({ photo }: Props) => {
+export const GalleryItem = ({ photo }: { photo: Photo }) => {
+  const [isImageLoaded, setIsImageLoaded] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+
   const handleToggleModal = () => {
+    if (!isImageLoaded) return;
     setIsOpen(prev => !prev);
   };
 
@@ -18,19 +18,35 @@ export const GalleryItem = ({ photo }: Props) => {
         onClick={handleToggleModal}
         className="w-fit p-4 rounded-xl overflow-hidden shadow-md bg-white hover:shadow-lg transition-shadow duration-300 cursor-pointer"
       >
+        {!isImageLoaded && (
+          <div className="w-[180px] h-[500px] bg-gray-200 animate-pulse rounded-xl" />
+        )}
+
         <img
           src={photo.url}
           alt="user photo"
-          className="w-[180px] h-fit object-cover"
+          className={`w-[180px] h-fit object-cover ${
+            isImageLoaded ? 'block' : 'hidden'
+          }`}
+          onLoad={() => setIsImageLoaded(true)}
         />
-        <div className="pt-2">
-          <div className="text-sm text-gray-500 text-right">
-            {getFormatDate(photo.created_at)}
+
+        {isImageLoaded && (
+          <div className="pt-2">
+            <div className="text-sm text-gray-500 text-right">
+              {getFormatDate(photo.created_at)}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
-      <GalleryModal isOpen={isOpen} onClose={handleToggleModal} photo={photo} />
+      {isImageLoaded && (
+        <GalleryModal
+          isOpen={isOpen}
+          onClose={handleToggleModal}
+          photo={photo}
+        />
+      )}
     </>
   );
 };

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -1,22 +1,36 @@
+import { GalleryModal } from '@/components/gallery/GalleryModal';
 import { Photo } from '@/types/photo';
 import { getFormatDate } from '@/utils/getFormatDate';
+import { useState } from 'react';
 
 interface Props {
   photo: Photo;
 }
 export const GalleryItem = ({ photo }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleToggleModal = () => {
+    setIsOpen(prev => !prev);
+  };
+
   return (
-    <div className="w-fit p-4 rounded-xl overflow-hidden shadow-md bg-white hover:shadow-lg transition-shadow duration-300">
-      <img
-        src={photo.url}
-        alt="user photo"
-        className="w-[180px] h-fit object-cover"
-      />
-      <div className="pt-2">
-        <div className="text-sm text-gray-500 text-right">
-          {getFormatDate(photo.created_at)}
+    <>
+      <div
+        onClick={handleToggleModal}
+        className="w-fit p-4 rounded-xl overflow-hidden shadow-md bg-white hover:shadow-lg transition-shadow duration-300 cursor-pointer"
+      >
+        <img
+          src={photo.url}
+          alt="user photo"
+          className="w-[180px] h-fit object-cover"
+        />
+        <div className="pt-2">
+          <div className="text-sm text-gray-500 text-right">
+            {getFormatDate(photo.created_at)}
+          </div>
         </div>
       </div>
-    </div>
+
+      <GalleryModal isOpen={isOpen} onClose={handleToggleModal} photo={photo} />
+    </>
   );
 };

--- a/src/components/gallery/GalleryItem.tsx
+++ b/src/components/gallery/GalleryItem.tsx
@@ -1,0 +1,22 @@
+import { Photo } from '@/types/photo';
+import { getFormatDate } from '@/utils/getFormatDate';
+
+interface Props {
+  photo: Photo;
+}
+export const GalleryItem = ({ photo }: Props) => {
+  return (
+    <div className="w-fit p-4 rounded-xl overflow-hidden shadow-md bg-white hover:shadow-lg transition-shadow duration-300">
+      <img
+        src={photo.url}
+        alt="user photo"
+        className="w-[180px] h-fit object-cover"
+      />
+      <div className="pt-2">
+        <div className="text-sm text-gray-500 text-right">
+          {getFormatDate(photo.created_at)}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/gallery/GalleryModal.tsx
+++ b/src/components/gallery/GalleryModal.tsx
@@ -1,0 +1,38 @@
+import { Button, Modal } from '@/components';
+import { Photo } from '@/types/photo';
+import { downloadImageFromUrl } from '@/utils/downloadImageFromUrl';
+import { getFormatDate } from '@/utils/getFormatDate';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  photo: Photo;
+}
+
+export const GalleryModal = ({ isOpen, onClose, photo }: Props) => {
+  const handleDownload = async () => {
+    await downloadImageFromUrl(photo.url, `${photo.name}`);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="flex gap-4">
+        <div className="flex flex-col">
+          <img
+            src={photo.url}
+            alt="user photo"
+            className="w-[180px] h-fit object-cover"
+          />
+          <div className="pt-2">
+            <div className="text-sm text-gray-500 text-right">
+              {getFormatDate(photo.created_at)}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col-reverse">
+          <Button label="다운받기" onClick={handleDownload} size="medium" />
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/gallery/GallerySection.tsx
+++ b/src/components/gallery/GallerySection.tsx
@@ -4,7 +4,7 @@ import { useGetUserPhotosQuery } from '@/hooks/queries';
 export const GallerySection = () => {
   const { photos } = useGetUserPhotosQuery();
   return (
-    <div className="grid grid-cols-5">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
       {photos.map(photo => (
         <GalleryItem photo={photo} />
       ))}

--- a/src/components/gallery/GallerySection.tsx
+++ b/src/components/gallery/GallerySection.tsx
@@ -3,6 +3,7 @@ import { useGetUserPhotosQuery } from '@/hooks/queries';
 
 export const GallerySection = () => {
   const { photos } = useGetUserPhotosQuery();
+
   return (
     <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
       {photos.map(photo => (

--- a/src/components/gallery/GallerySection.tsx
+++ b/src/components/gallery/GallerySection.tsx
@@ -1,0 +1,13 @@
+import { GalleryItem } from '@/components/gallery';
+import { useGetUserPhotosQuery } from '@/hooks/queries';
+
+export const GallerySection = () => {
+  const { photos } = useGetUserPhotosQuery();
+  return (
+    <div className="grid grid-cols-5">
+      {photos.map(photo => (
+        <GalleryItem photo={photo} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/gallery/GallerySection.tsx
+++ b/src/components/gallery/GallerySection.tsx
@@ -1,13 +1,22 @@
-import { GalleryItem } from '@/components/gallery';
+import { GalleryContentSkeleton, GalleryItem } from '@/components/gallery';
 import { useGetUserPhotosQuery } from '@/hooks/queries';
+import { Suspense } from 'react';
 
 export const GallerySection = () => {
+  return (
+    <Suspense fallback={<GalleryContentSkeleton />}>
+      <GalleryContent />
+    </Suspense>
+  );
+};
+
+const GalleryContent = () => {
   const { photos } = useGetUserPhotosQuery();
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
       {photos.map(photo => (
-        <GalleryItem photo={photo} />
+        <GalleryItem key={photo.name} photo={photo} />
       ))}
     </div>
   );

--- a/src/components/gallery/index.ts
+++ b/src/components/gallery/index.ts
@@ -1,2 +1,3 @@
+export * from './GalleryContentSkeleton';
 export * from './GalleryItem';
 export * from './GallerySection';

--- a/src/components/gallery/index.ts
+++ b/src/components/gallery/index.ts
@@ -1,0 +1,2 @@
+export * from './GalleryItem';
+export * from './GallerySection';

--- a/src/components/gallery/index.ts
+++ b/src/components/gallery/index.ts
@@ -1,3 +1,4 @@
 export * from './GalleryContentSkeleton';
 export * from './GalleryItem';
+export * from './GalleryModal';
 export * from './GallerySection';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,5 +6,8 @@ export { default as Header } from './_common/Header/Header';
 export { default as Layout } from './_common/Layout/Layout';
 export { default as MainLayout } from './_common/Layout/MainLayout';
 export { default as Marquee } from './_common/Marquee/Marquee';
-export { default as ToastMessage } from './_common/ToastMessage/ToastMessage';
 export { default as Modal } from './_common/Modal/Modal';
+export { default as ToastMessage } from './_common/ToastMessage/ToastMessage';
+
+export * from './_common/Layout/GlobalError';
+export * from './_common/Layout/GlobalLoading';

--- a/src/components/photo/PhotoDownloadSection.tsx
+++ b/src/components/photo/PhotoDownloadSection.tsx
@@ -17,7 +17,9 @@ const PhotoDownloadSection = () => {
   useEffect(() => {
     if (isSuccess) {
       setShowToast(true);
-      setTimeout(() => setShowToast(false), 3000);
+
+      const timeoutId = setTimeout(() => setShowToast(false), 3000);
+      return () => clearTimeout(timeoutId);
     }
   }, [isSuccess]);
 

--- a/src/components/photo/PhotoDownloadSection.tsx
+++ b/src/components/photo/PhotoDownloadSection.tsx
@@ -1,25 +1,36 @@
-import { Button } from '@/components';
+import { Button, ToastMessage } from '@/components';
 import { PhotoFrame } from '@/components/photo';
 import { usePhotoDownload } from '@/hooks';
 import { usePhotoUpload } from '@/hooks/usePhotoUpload';
 import { useEffect, useRef, useState } from 'react';
 
 const PhotoDownloadSection = () => {
+  const [showToast, setShowToast] = useState(false);
   const downloadDivRef = useRef<HTMLDivElement>(null);
   const { handleDownload, isLoading } = usePhotoDownload(downloadDivRef);
   const { handleUpload, isSuccess } = usePhotoUpload(downloadDivRef);
 
   useEffect(() => {
     handleUpload();
-    if (isSuccess) alert('사진 업로드 성공');
   }, []);
 
+  useEffect(() => {
+    if (isSuccess) {
+      setShowToast(true);
+      setTimeout(() => setShowToast(false), 3000);
+    }
+  }, [isSuccess]);
+
   return (
-    <div className="flex flex-col items-end w-fit h-fit md:flex-row p-5 gap-5 bg-white rounded-2xl">
-      {/* 사진 프레임 */}
-      <div ref={downloadDivRef}>
-        <PhotoFrame />
-      </div>
+    <>
+      {showToast && (
+        <ToastMessage message="사진 업로드에 성공했습니다! 이제 내 갤러리에서 다시 볼 수 있어요!" />
+      )}
+      <div className="flex flex-col items-end w-fit h-fit md:flex-row p-5 gap-5 bg-white rounded-2xl">
+        {/* 사진 프레임 */}
+        <div ref={downloadDivRef}>
+          <PhotoFrame />
+        </div>
 
         {/* 다운로드 버튼 */}
         <Button

--- a/src/components/photo/PhotoDownloadSection.tsx
+++ b/src/components/photo/PhotoDownloadSection.tsx
@@ -1,9 +1,18 @@
 import { Button } from '@/components';
 import { PhotoFrame } from '@/components/photo';
 import { usePhotoDownload } from '@/hooks';
+import { usePhotoUpload } from '@/hooks/usePhotoUpload';
+import { useEffect, useRef } from 'react';
 
 const PhotoDownloadSection = () => {
-  const { downloadDivRef, isLoading, handleDownload } = usePhotoDownload();
+  const downloadDivRef = useRef<HTMLDivElement>(null);
+  const { handleDownload, isLoading } = usePhotoDownload(downloadDivRef);
+  const { handleUpload, isSuccess } = usePhotoUpload(downloadDivRef);
+
+  useEffect(() => {
+    handleUpload();
+    if (isSuccess) alert('사진 업로드 성공');
+  }, []);
 
   return (
     <div className="flex flex-col items-end w-fit h-fit md:flex-row p-5 gap-5 bg-white rounded-2xl">

--- a/src/components/photo/PhotoDownloadSection.tsx
+++ b/src/components/photo/PhotoDownloadSection.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components';
 import { PhotoFrame } from '@/components/photo';
 import { usePhotoDownload } from '@/hooks';
 import { usePhotoUpload } from '@/hooks/usePhotoUpload';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const PhotoDownloadSection = () => {
   const downloadDivRef = useRef<HTMLDivElement>(null);
@@ -21,14 +21,15 @@ const PhotoDownloadSection = () => {
         <PhotoFrame />
       </div>
 
-      {/* 다운로드 버튼 */}
-      <Button
-        label={isLoading ? '다운로드 중...' : '사진 다운로드 🔽'}
-        onClick={handleDownload}
-        size="medium"
-        color="pink"
-      />
-    </div>
+        {/* 다운로드 버튼 */}
+        <Button
+          label={isLoading ? '다운로드 중...' : '사진 다운로드 🔽'}
+          onClick={handleDownload}
+          size="medium"
+          color="pink"
+        />
+      </div>
+    </>
   );
 };
 

--- a/src/components/profile/ProfileSection.tsx
+++ b/src/components/profile/ProfileSection.tsx
@@ -1,4 +1,4 @@
-import useUserContext from '@/hooks/useUserContext';
+import { useUserContext } from '@/hooks';
 import { getElapsedDays } from '@/utils/getElapsedDays';
 
 export const ProfileSection = () => {

--- a/src/components/profile/ProfileSection.tsx
+++ b/src/components/profile/ProfileSection.tsx
@@ -17,7 +17,7 @@ export const ProfileSection = () => {
         <span className="text-base text-amber-900 mt-1">
           토스터 부스와 함께한지{' '}
           <strong className="text-amber-500">
-            {getElapsedDays(user?.created_at ?? '')}일 🧡
+            {getElapsedDays(user?.created_at ?? '') + 1}일 🧡
           </strong>
         </span>
       </div>

--- a/src/components/profile/ProfileSection.tsx
+++ b/src/components/profile/ProfileSection.tsx
@@ -1,0 +1,26 @@
+import useUserContext from '@/hooks/useUserContext';
+import { getElapsedDays } from '@/utils/getElapsedDays';
+
+export const ProfileSection = () => {
+  const { user } = useUserContext();
+
+  return (
+    <div className="flex flex-row items-center gap-5 w-full h-[120px] bg-amber-100 px-8 py-4 rounded-2xl shadow-sm">
+      <div className="w-16 h-16 rounded-full bg-amber-300 flex items-center justify-center text-xl font-bold text-white">
+        {user?.name?.[0] || '🙂'}
+      </div>
+
+      <div className="flex flex-col">
+        <span className="text-2xl font-semibold text-gray-800">
+          안녕하세요, {user?.name} 님!
+        </span>
+        <span className="text-base text-amber-900 mt-1">
+          토스터 부스와 함께한지{' '}
+          <strong className="text-amber-500">
+            {getElapsedDays(user?.created_at ?? '')}일 🧡
+          </strong>
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/profile/index.ts
+++ b/src/components/profile/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileSection';

--- a/src/context/queryKeys.ts
+++ b/src/context/queryKeys.ts
@@ -1,0 +1,3 @@
+export const QUERY_KEYS = {
+    userPhotos : 'userPhotos'
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,3 +9,4 @@ export { default as useTakeMobilePhoto } from './useTakeMobilePhoto';
 export { default as useTakePhoto } from './useTakePhoto';
 export { default as useToasterMobileRiv } from './useToasterMobileRiv';
 export { default as useToasterRiv } from './useToasterRiv';
+export * from './useUserContext';

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -1,2 +1,3 @@
 export { default as useGetFramesByEventQuery } from './useGetFramesByEventQuery';
 export { default as useGetNoticeQuery } from './useGetNoticeQuery';
+export * from './useGetUserPhotosQuery';

--- a/src/hooks/queries/useGetUserPhotosQuery.ts
+++ b/src/hooks/queries/useGetUserPhotosQuery.ts
@@ -1,0 +1,32 @@
+import useUserContext from '@/hooks/useUserContext';
+import { getStoragePrivateUrl, getUserPhotos } from '@/service/supabase';
+import { Photo } from '@/types/photo';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export const useGetUserPhotosQuery = () => {
+  const { user } = useUserContext();
+  const {
+    data: photos,
+    isLoading,
+    isError,
+  } = useSuspenseQuery<Photo[]>({
+    queryKey: ['userPhotos', user],
+    queryFn: async () => {
+      if (!user) return [];
+
+      const data = await getUserPhotos(user.id);
+      const photos = await Promise.all(
+        data.map(async photo => ({
+          ...photo,
+          url: await getStoragePrivateUrl(
+            `photos/${user.id}/photos/${photo.name}`,
+          ),
+        })),
+      );
+
+      return photos;
+    },
+  });
+
+  return { photos, isLoading, isError };
+};

--- a/src/hooks/queries/useGetUserPhotosQuery.ts
+++ b/src/hooks/queries/useGetUserPhotosQuery.ts
@@ -1,4 +1,5 @@
-import useUserContext from '@/hooks/useUserContext';
+import { QUERY_KEYS } from '@/context/queryKeys';
+import { useUserContext } from '@/hooks';
 import { getStoragePrivateUrl, getUserPhotos } from '@/service/supabase';
 import { Photo } from '@/types/photo';
 import { useSuspenseQuery } from '@tanstack/react-query';
@@ -10,7 +11,7 @@ export const useGetUserPhotosQuery = () => {
     isLoading,
     isError,
   } = useSuspenseQuery<Photo[]>({
-    queryKey: ['userPhotos', user],
+    queryKey: [QUERY_KEYS.userPhotos, user],
     queryFn: async () => {
       if (!user) return [];
 

--- a/src/hooks/queries/usePostUserPhotoMutation.ts
+++ b/src/hooks/queries/usePostUserPhotoMutation.ts
@@ -1,0 +1,19 @@
+import { QUERY_KEYS } from '@/context/queryKeys';
+import { postUserPhoto } from '@/service/supabase/postUserPhoto';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const usePostUserPhotoMutation = () => {
+  const queryClient = useQueryClient();
+
+  const { mutateAsync: uploadPhoto, ...rest } = useMutation({
+    mutationFn: postUserPhoto,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.userPhotos],
+        exact: false,
+      });
+    },
+  });
+
+  return { uploadPhoto, ...rest };
+};

--- a/src/hooks/usePhotoDownload.ts
+++ b/src/hooks/usePhotoDownload.ts
@@ -2,10 +2,12 @@ import { buildBlobWithRetry } from '@/utils/buildBlobWithRetry';
 import { getFormatDate } from '@/utils/getFormatDate';
 import { isSafari } from '@/utils/isSafari';
 import saveAs from 'file-saver';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
-const usePhotoDownload = () => {
-  const downloadDivRef = useRef<HTMLDivElement>(null);
+const usePhotoDownload = (
+  downloadDivRef: React.RefObject<HTMLDivElement | null>,
+) => {
+  // const downloadDivRef = useRef<HTMLDivElement>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   const handleDownload = async () => {
@@ -49,7 +51,7 @@ const usePhotoDownload = () => {
     }
   };
 
-  return { downloadDivRef, isLoading, handleDownload };
+  return { handleDownload, isLoading };
 };
 
 export default usePhotoDownload;

--- a/src/hooks/usePhotoUpload.ts
+++ b/src/hooks/usePhotoUpload.ts
@@ -1,0 +1,63 @@
+import useUserContext from '@/hooks/useUserContext';
+import { supabaseClient } from '@/service/supabase';
+import { buildBlobWithRetry } from '@/utils/buildBlobWithRetry';
+import { isSafari } from '@/utils/isSafari';
+import { useState } from 'react';
+
+export const uploadPhoto = async (userId: string, file: Blob) => {
+  const timestamp = new Date().toISOString();
+  const filePath = `${userId}/photos/${timestamp}.png`;
+
+  const { error } = await supabaseClient.storage
+    .from('photos')
+    .upload(filePath, file, {
+      cacheControl: '3600',
+      upsert: false,
+    });
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const usePhotoUpload = (
+  downloadDivRef: React.RefObject<HTMLDivElement | null>,
+) => {
+  const [isSuccess, setSuccess] = useState(false);
+  const { user } = useUserContext(); // 유저 정보
+
+  const handleUpload = async () => {
+    if (!downloadDivRef.current || !user) return;
+
+    const images = downloadDivRef.current.querySelectorAll('img');
+    const loadPromises = Array.from(images).map(
+      img =>
+        new Promise(resolve => {
+          if (img.complete) return resolve(true);
+          img.onload = () => resolve(true);
+          img.onerror = () => resolve(true);
+        }),
+    );
+
+    try {
+      await Promise.all(loadPromises);
+      if (isSafari()) {
+        await new Promise(resolve => setTimeout(resolve, 3000));
+      }
+
+      const blob = await buildBlobWithRetry(downloadDivRef.current, isSafari());
+      if (!blob) {
+        console.error('Blob 생성 실패');
+        return;
+      }
+
+      await uploadPhoto(user.id, blob);
+      setSuccess(true);
+    } catch (error) {
+      console.error('사진 저장 실패:', error);
+      setSuccess(false);
+    }
+  };
+
+  return { handleUpload, isSuccess };
+};

--- a/src/hooks/usePhotoUpload.ts
+++ b/src/hooks/usePhotoUpload.ts
@@ -1,30 +1,13 @@
-import useUserContext from '@/hooks/useUserContext';
-import { supabaseClient } from '@/service/supabase';
+import { useUserContext } from '@/hooks';
+import { usePostUserPhotoMutation } from '@/hooks/queries/usePostUserPhotoMutation';
 import { buildBlobWithRetry } from '@/utils/buildBlobWithRetry';
 import { isSafari } from '@/utils/isSafari';
-import { useState } from 'react';
-
-export const uploadPhoto = async (userId: string, file: Blob) => {
-  const timestamp = new Date().toISOString();
-  const filePath = `${userId}/photos/${timestamp}.png`;
-
-  const { error } = await supabaseClient.storage
-    .from('photos')
-    .upload(filePath, file, {
-      cacheControl: '3600',
-      upsert: false,
-    });
-
-  if (error) {
-    throw error;
-  }
-};
 
 export const usePhotoUpload = (
   downloadDivRef: React.RefObject<HTMLDivElement | null>,
 ) => {
-  const [isSuccess, setSuccess] = useState(false);
-  const { user } = useUserContext(); // 유저 정보
+  const { user } = useUserContext();
+  const { uploadPhoto, isSuccess } = usePostUserPhotoMutation();
 
   const handleUpload = async () => {
     if (!downloadDivRef.current || !user) return;
@@ -51,11 +34,9 @@ export const usePhotoUpload = (
         return;
       }
 
-      await uploadPhoto(user.id, blob);
-      setSuccess(true);
+      await uploadPhoto({ userId: user.id, file: blob });
     } catch (error) {
       console.error('사진 저장 실패:', error);
-      setSuccess(false);
     }
   };
 

--- a/src/hooks/useUserContext.ts
+++ b/src/hooks/useUserContext.ts
@@ -1,12 +1,10 @@
 import { UserContext } from '@/context';
 import { useContext } from 'react';
 
-const useUserContext = () => {
+export const useUserContext = () => {
   const state = useContext(UserContext);
   if (!state) throw new Error('UserProvider not found');
 
   const { user, setUser } = state;
   return { user, setUser };
 };
-
-export default useUserContext;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,10 +1,9 @@
-import useUserContext from '@/hooks/useUserContext';
+import { ProfileSection } from '@/components/profile';
 
 export const MyPage = () => {
-  const { user } = useUserContext();
   return (
-    <div className="flex relative w-full md:h-[92vh] pt-2 pb-2 mt-[50px]">
-      MyPage 안녕하세요 {user?.name} 님!
+    <div className="flex flex-col gap-5 relative w-full h-full pt-2 pb-2 mt-[50px]">
+      <ProfileSection />
     </div>
   );
 };

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,9 +1,11 @@
+import { GallerySection } from '@/components/gallery';
 import { ProfileSection } from '@/components/profile';
 
 export const MyPage = () => {
   return (
     <div className="flex flex-col gap-5 relative w-full h-full pt-2 pb-2 mt-[50px]">
       <ProfileSection />
+      <GallerySection />
     </div>
   );
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/pages';
 import { createBrowserRouter, Outlet } from 'react-router-dom';
 
-const router = createBrowserRouter([
+export const router = createBrowserRouter([
   {
     element: (
       <Layout>
@@ -56,5 +56,3 @@ const router = createBrowserRouter([
     ],
   },
 ]);
-
-export default router;

--- a/src/service/amplitude/trackEvent.ts
+++ b/src/service/amplitude/trackEvent.ts
@@ -15,7 +15,7 @@ export const trackFilterButton = (filter: string) => {
 };
 
 export const trackFrameButton = (frame: string) => {
-  amplitudeService.customTrack(`[Click] ${frame} 필터 버튼`);
+  amplitudeService.customTrack(`[Click] ${frame} 프레임 버튼`);
 };
 
 export const trackFinishedEditButton = () => {

--- a/src/service/supabase/getFrames.ts
+++ b/src/service/supabase/getFrames.ts
@@ -1,7 +1,7 @@
 import { PRIORITY_FRAMES_TAGS } from '@/constants/framesTag';
 import { getStoragePublicUrl, supabaseClient } from '@/service/supabase';
 
-const getFrames = async (tags: string[]) => {
+export const getFrames = async (tags: string[]) => {
   const { data, error } = await supabaseClient
     .from('frames')
     .select('*')
@@ -24,5 +24,3 @@ const getFrames = async (tags: string[]) => {
     })
     .sort((a, b) => a._priorityIndex - b._priorityIndex);
 };
-
-export default getFrames;

--- a/src/service/supabase/getNotice.ts
+++ b/src/service/supabase/getNotice.ts
@@ -17,5 +17,3 @@ export const getNotice = async (): Promise<Notice> => {
     url: getStoragePublicUrl(data.image_path),
   };
 };
-
-export default getNotice;

--- a/src/service/supabase/getStoragePrivateUrl.ts
+++ b/src/service/supabase/getStoragePrivateUrl.ts
@@ -1,0 +1,10 @@
+import { supabaseClient } from '@/service/supabase';
+
+export const getStoragePrivateUrl = async (filePath: string) => {
+  const { data, error } = await supabaseClient.storage
+    .from('')
+    .createSignedUrl(filePath, 60 * 60);
+
+  if (error) throw error;
+  return data.signedUrl;
+};

--- a/src/service/supabase/getStoragePublicUrl.ts
+++ b/src/service/supabase/getStoragePublicUrl.ts
@@ -1,9 +1,7 @@
 import { supabaseClient } from '@/service/supabase';
 
-const getStoragePublicUrl = (filePath: string) => {
+export const getStoragePublicUrl = (filePath: string) => {
   const { data } = supabaseClient.storage.from('').getPublicUrl(filePath);
 
   return data.publicUrl;
 };
-
-export default getStoragePublicUrl;

--- a/src/service/supabase/getUserInfo.ts
+++ b/src/service/supabase/getUserInfo.ts
@@ -1,4 +1,4 @@
-import supabaseClient from '@/service/supabase/supabaseClient';
+import { supabaseClient } from '@/service/supabase';
 
 export const getUserInfo = async () => {
   const {
@@ -8,7 +8,7 @@ export const getUserInfo = async () => {
   if (user) {
     const { data: profileData } = await supabaseClient
       .from('profiles')
-      .select('id, email, name')
+      .select('*')
       .eq('id', user.id)
       .single();
 

--- a/src/service/supabase/getUserPhotos.ts
+++ b/src/service/supabase/getUserPhotos.ts
@@ -1,0 +1,14 @@
+import { supabaseClient } from '@/service/supabase';
+
+export const getUserPhotos = async (userId: string) => {
+  const { data, error } = await supabaseClient.storage
+    .from('photos')
+    .list(`${userId}/photos`, {
+      limit: 100,
+      sortBy: { column: 'created_at', order: 'desc' },
+    });
+
+  if (error) throw error;
+
+  return data;
+};

--- a/src/service/supabase/index.ts
+++ b/src/service/supabase/index.ts
@@ -1,7 +1,9 @@
-export { default as getStoragePublicUrl } from './getStoragePublicUrl';
-export { default as supabaseClient } from './supabaseClient';
+export * from './getStoragePrivateUrl';
+export * from './getStoragePublicUrl';
+export * from './supabaseClient';
 
 // apis
-export { default as getFrames } from './getFrames';
-export { default as getNotice } from './getNotice';
+export * from './getFrames';
+export * from './getNotice';
 export * from './getUserInfo';
+export * from './getUserPhotos';

--- a/src/service/supabase/postUserPhoto.ts
+++ b/src/service/supabase/postUserPhoto.ts
@@ -1,0 +1,23 @@
+import { supabaseClient } from '@/service/supabase';
+
+export const postUserPhoto = async ({
+  userId,
+  file,
+}: {
+  userId: string;
+  file: Blob;
+}) => {
+  const timestamp = new Date().toISOString();
+  const filePath = `${userId}/photos/${timestamp}.png`;
+
+  const { error } = await supabaseClient.storage
+    .from('photos')
+    .upload(filePath, file, {
+      cacheControl: '3600',
+      upsert: false,
+    });
+
+  if (error) {
+    throw error;
+  }
+};

--- a/src/service/supabase/supabaseClient.ts
+++ b/src/service/supabase/supabaseClient.ts
@@ -1,8 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseClient = createClient(
+export const supabaseClient = createClient(
   import.meta.env.VITE_SUPABASE_PROJECT_URL,
   import.meta.env.VITE_SUPABASE_ANON_KEY,
 );
-
-export default supabaseClient;

--- a/src/types/photo.ts
+++ b/src/types/photo.ts
@@ -1,0 +1,6 @@
+export interface Photo {
+  id: string;
+  name: string;
+  url: string;
+  created_at: string;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -2,4 +2,5 @@ export interface User {
   id: string;
   name: string;
   email: string;
+  created_at: string;
 }

--- a/src/utils/downloadImageFromUrl.ts
+++ b/src/utils/downloadImageFromUrl.ts
@@ -1,0 +1,7 @@
+import { saveAs } from 'file-saver';
+
+export const downloadImageFromUrl = async (url: string, filename: string) => {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  saveAs(blob, filename);
+};

--- a/src/utils/getElapsedDays.ts
+++ b/src/utils/getElapsedDays.ts
@@ -1,0 +1,11 @@
+export const getElapsedDays = (startDate: string | Date): number => {
+  const start = new Date(startDate);
+  const now = new Date();
+
+  const msPerDay = 1000 * 60 * 60 * 24;
+
+  const utc1 = Date.UTC(start.getFullYear(), start.getMonth(), start.getDate());
+  const utc2 = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+
+  return Math.floor((utc2 - utc1) / msPerDay);
+};

--- a/src/utils/getFormatDate.ts
+++ b/src/utils/getFormatDate.ts
@@ -1,4 +1,5 @@
-export const getFormatDate = (date: Date) => {
+export const getFormatDate = (date: Date | string) => {
+  if (typeof date === 'string') date = new Date(date);
   return `${date.getFullYear()}.${(date.getMonth() + 1)
     .toString()
     .padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,6 +181,13 @@
   dependencies:
     "@babel/types" "^7.27.0"
 
+"@babel/runtime@^7.12.5":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
+  integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.26.9", "@babel/template@^7.27.0":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.0.tgz#b253e5406cc1df1c57dcd18f11760c2dbf40c0b4"
@@ -2003,6 +2010,13 @@ react-dom@^19.0.0:
   dependencies:
     scheduler "^0.26.0"
 
+react-error-boundary@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-5.0.0.tgz#6b6c7e075c922afb0283147e5b084efa44e68570"
+  integrity sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-router-dom@^7.4.0:
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.5.2.tgz#fb00e4ac7e1fcc6cb9861458d3ddb2d1b074ca79"
@@ -2023,6 +2037,11 @@ react@^19.0.0:
   version "19.1.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.1.0.tgz#926864b6c48da7627f004795d6cce50e90793b75"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## 🌱 관련 이슈 

- #41 
- #43  

## 🍀 기획 배경
사용자가 사진 촬영을 마치고 저장 페이지까지 도달하면, 사진을 자동으로 아카이빙할 수 있도록 기능을 추가했습니다.

**❗ 아카이빙 기능 필요 이유**
사용자가 찍은 사진을 안전하게 보관하고 싶어하는 니즈 존재
직접 저장하지 않아도 자동으로 사진이 업로드되면 사용자 경험(UX) 향상
저장된 사진을 갤러리에서 재다운로드할 수 있는 기능도 제공

## ✨ 작업 내용
- 사진 자동 업로드 기능 추가
   - 마지막 저장 페이지 도달 시 로그인한 유저 사진 자동 아카이빙
- 마이페이지 유저 프로필 섹션 작업 (가입일 기준 경과일수 표시)
- 사진 갤러리 화면 제작
- 갤러리 모달에서 사진 재다운로드 기능 추가
- 업로드 완료 후 저장 페이지에서 토스트 메시지 전달
- 갤러리 로딩 중 스켈레톤 적용 (레이아웃 쉬프트 방지
- 글로벌 Suspense 및 ErrorBoundary 적용
## 📸 작업 결과물

| 마이페이지 프로필 및 갤러리 | 사진 재다운로드 모달 |
|:---:|:---:|
| ![스크린샷1](https://github.com/user-attachments/assets/aeb0e4a9-463f-4fca-8028-09264726fe0c) | ![스크린샷2](https://github.com/user-attachments/assets/07f254bf-70fc-45d2-abe9-e774fa2f003f) |

---